### PR TITLE
238 regler le responsive dans la page admin

### DIFF
--- a/app/assets/css/admin.css
+++ b/app/assets/css/admin.css
@@ -308,6 +308,7 @@
 /* Responsive Tablette */
 @media (max-width: 992px) {
     .admin-layout {
+        display: flex;
         flex-direction: column;
     }
 
@@ -357,11 +358,13 @@
     .admin-nav-list {
         margin-top: 10px;
         display: flex;
-        gap: 10px;
+        flex-wrap: wrap;
+        gap: 8px;
     }
 
     .admin-nav-list li {
-        flex: 1;
+        flex: 1 1 calc(33% - 8px);
+        min-width: 0;
     }
 
     .admin-nav-link {
@@ -512,12 +515,15 @@
     }
 
     .admin-search-input {
+        flex: 1 1 auto;
+        min-width: 0;
         font-size: 0.9rem;
         padding: 10px 12px;
     }
 
     .admin-search-btn,
     .admin-reset-btn {
+        flex-shrink: 0;
         padding: 10px 12px;
     }
 
@@ -529,18 +535,19 @@
         margin-bottom: 15px;
     }
 
-    /* Grille pour les filtres de rôle (3 colonnes) */
+    /* Grille pour les filtres de rôle (2 colonnes) */
     .role-filters {
         display: grid;
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(2, 1fr);
         gap: 8px;
     }
 
     .role-filters .admin-nav-link {
         padding: 10px 8px;
         font-size: 0.85rem;
-        flex-direction: column;
-        gap: 5px;
+        flex-direction: row;
+        gap: 6px;
+        justify-content: center;
     }
 }
 
@@ -566,5 +573,13 @@
     .admin-table td::before {
         width: 80px;
         font-size: 0.85rem;
+    }
+
+    .admin-search-input {
+        flex: 1 1 100%;
+    }
+
+    .role-filters {
+        grid-template-columns: repeat(2, 1fr);
     }
 }

--- a/app/assets/css/dark-mode.css
+++ b/app/assets/css/dark-mode.css
@@ -48,7 +48,7 @@
     --shadow-lg: rgba(0, 0, 0, 0.2);
 
     /* Gradients */
-    --gradient-primary: linear-gradient(90deg, rgba(181, 35, 235, 1) 0%, rgba(87, 89, 199, 1) 100%);
+    --gradient-primary: linear-gradient(90deg, rgba(181, 35, 235, 0.9) 0%, rgba(87, 89, 199, 0.9) 100%);
     --gradient-hero: linear-gradient(90deg, rgba(181, 35, 235, 0.9) 0%, rgba(87, 89, 199, 0.9) 100%);
     --gradient-content: linear-gradient(180deg, #f8f9ff 0%, #dea4f1 100%);
     --gradient-sidebar: linear-gradient(135deg, #667eea 0%, #764ba2 100%);

--- a/app/assets/css/navbar.css
+++ b/app/assets/css/navbar.css
@@ -64,7 +64,8 @@
 /* Dans navbar.css */
 .dark-mode .nav-logo img {
     opacity: 1;
-    filter: none !important; /* On retire les filtres de luminosité */
+    filter: none !important;
+    /* On retire les filtres de luminosité */
     background: transparent !important;
 }
 


### PR DESCRIPTION
This pull request makes several improvements to the admin interface's responsiveness and layout, especially for tablet and mobile screens. It also includes minor adjustments to dark mode gradient opacity and a clarification in the navbar logo styling.

**Admin layout and responsiveness improvements:**

* Changed `.admin-layout` to use `display: flex` for better column stacking on tablet screens.
* Updated `.admin-nav-list` and its list items to wrap flexibly and use a more responsive column sizing, improving navigation usability on smaller screens.
* Improved `.admin-search-input` and related button styles to ensure proper flex behavior and prevent layout issues in search areas.
* Modified `.role-filters` grid from three columns to two, and adjusted filter link layout for better alignment and spacing. [[1]](diffhunk://#diff-e99d091039bbf86eeebd8cf861437171c084c4836a7a577e8c76550abd1db936L532-R550) [[2]](diffhunk://#diff-e99d091039bbf86eeebd8cf861437171c084c4836a7a577e8c76550abd1db936R577-R584)

**Visual and style adjustments:**

* Reduced opacity in the `--gradient-primary` variable for dark mode, making gradients less intense.
* Added a comment and clarified the removal of filters for the logo image in dark mode.