### PR TITLE
Mettre une modale plutot quune alert en js pour les confirmations

### DIFF
--- a/app/Modules/views/articles/listArticlesView.php
+++ b/app/Modules/views/articles/listArticlesView.php
@@ -96,7 +96,9 @@ start_page("Nos articles", true, $user ?? null);
                                           class="delete-article-form">
                                         <?= csrfField() ?>
                                         <input type="hidden" name="slug" value="<?= htmlspecialchars($article->getSlug()) ?>">
-                                        <button type="submit" class="btn-delete" onclick="return confirm('Êtes-vous sûr de vouloir supprimer cet article ? Cette action est irréversible.');">
+                                        <button type="button" class="btn-delete"
+                                                data-confirm-title="Supprimer l'article"
+                                                data-confirm-msg="Êtes-vous sûr de vouloir supprimer cet article ? Cette action est irréversible.">
                                             Supprimer
                                         </button>
                                     </form>

--- a/app/Modules/views/events/showEventView.php
+++ b/app/Modules/views/events/showEventView.php
@@ -118,7 +118,9 @@ $userId = $user['user_id'] ?? null;
                 <form method="post" action="index.php?page=deleteEvent" style="margin: 0;">
                     <input type="hidden" name="event_id" value="<?= $eventId ?>">
                     <?= $csrf->getTokenField() ?>
-                    <button type="submit" class="btn-delete" onclick="return confirm('Êtes-vous sûr de vouloir supprimer cet événement ? Cette action est irréversible.');">Supprimer</button>
+                    <button type="button" class="btn-delete"
+                            data-confirm-title="Supprimer l'événement"
+                            data-confirm-msg="Êtes-vous sûr de vouloir supprimer cet événement ? Cette action est irréversible.">Supprimer</button>
                 </form>
 
                 <form action="index.php?page=exportUserEvent" method="post" style="margin: 0;">

--- a/app/assets/js/admin/admin-section.js
+++ b/app/assets/js/admin/admin-section.js
@@ -4,46 +4,46 @@
  */
 const ADMIN_ACTION_CONFIGS = {
     unblock: {
-        title:       'Débloquer l\'utilisateur',
-        msg:         'Êtes-vous sûr de vouloir débloquer cet utilisateur ?',
-        icon:        'fas fa-unlock',
+        title: 'Débloquer l\'utilisateur',
+        msg: 'Êtes-vous sûr de vouloir débloquer cet utilisateur ?',
+        icon: 'fas fa-unlock',
         confirmText: 'Débloquer',
-        danger:      false
+        danger: false
     },
     restore: {
-        title:       'Réactiver l\'utilisateur',
-        msg:         'Êtes-vous sûr de vouloir réactiver ce compte supprimé ?',
-        icon:        'fas fa-undo',
+        title: 'Réactiver l\'utilisateur',
+        msg: 'Êtes-vous sûr de vouloir réactiver ce compte supprimé ?',
+        icon: 'fas fa-undo',
         confirmText: 'Réactiver',
-        danger:      false
+        danger: false
     },
     promote: {
-        title:       'Promouvoir en administrateur',
-        msg:         'Êtes-vous sûr de vouloir promouvoir cet utilisateur en tant qu\'admin ?',
-        icon:        'fas fa-user-shield',
+        title: 'Promouvoir en administrateur',
+        msg: 'Êtes-vous sûr de vouloir promouvoir cet utilisateur en tant qu\'admin ?',
+        icon: 'fas fa-user-shield',
         confirmText: 'Promouvoir',
-        danger:      false
+        danger: false
     },
     demote: {
-        title:       'Rétrograder en utilisateur',
-        msg:         'Êtes-vous sûr de vouloir rétrograder cet administrateur en utilisateur normal ?',
-        icon:        'fas fa-user-minus',
+        title: 'Rétrograder en utilisateur',
+        msg: 'Êtes-vous sûr de vouloir rétrograder cet administrateur en utilisateur normal ?',
+        icon: 'fas fa-user-minus',
         confirmText: 'Rétrograder',
-        danger:      true
+        danger: true
     },
     block: {
-        title:       'Bloquer l\'utilisateur',
-        msg:         'Êtes-vous sûr de vouloir bloquer cet utilisateur ?',
-        icon:        'fas fa-ban',
+        title: 'Bloquer l\'utilisateur',
+        msg: 'Êtes-vous sûr de vouloir bloquer cet utilisateur ?',
+        icon: 'fas fa-ban',
         confirmText: 'Bloquer',
-        danger:      true
+        danger: true
     },
     soft_delete: {
-        title:       'Supprimer l\'utilisateur',
-        msg:         'Êtes-vous sûr de vouloir supprimer cet utilisateur ? Cette action est réversible par un super-admin.',
-        icon:        'fas fa-trash-alt',
+        title: 'Supprimer l\'utilisateur',
+        msg: 'Êtes-vous sûr de vouloir supprimer cet utilisateur ? Cette action est réversible par un super-admin.',
+        icon: 'fas fa-trash-alt',
         confirmText: 'Supprimer',
-        danger:      true
+        danger: true
     }
 };
 
@@ -67,10 +67,10 @@ function confirmAdminAction(action, onConfirm) {
         onConfirm,
         null,
         {
-            icon:        cfg.icon,
+            icon: cfg.icon,
             confirmText: cfg.confirmText,
-            cancelText:  'Annuler',
-            danger:      cfg.danger
+            cancelText: 'Annuler',
+            danger: cfg.danger
         }
     );
 }
@@ -81,13 +81,13 @@ document.addEventListener('click', (e) => {
     e.preventDefault();
 
     const button = e.target;
-    const form   = button.closest('form');
+    const form = button.closest('form');
     const action = button.value;
 
-    const input   = document.createElement('input');
-    input.type    = 'hidden';
-    input.name    = 'action';
-    input.value   = action;
+    const input = document.createElement('input');
+    input.type = 'hidden';
+    input.name = 'action';
+    input.value = action;
     form.appendChild(input);
 
     confirmAdminAction(action, () => submitAdminAction(form));
@@ -99,7 +99,7 @@ document.addEventListener('change', (e) => {
     e.preventDefault();
 
     const select = e.target;
-    const form   = select.closest('form');
+    const form = select.closest('form');
     const action = select.value;
 
     if (!action) return;
@@ -117,16 +117,16 @@ function submitAdminAction(form) {
             'X-Requested-With': 'XMLHttpRequest'
         }
     })
-    .then(response => response.json())
-    .then(data => {
-        if (data.success) {
-            window.location.reload();
-        } else {
-            alert('Erreur: ' + data.message);
-        }
-    })
-    .catch(error => {
-        console.error('Erreur: ', error);
-        alert('Une erreur est survenue lors de la requête.');
-    });
+        .then(response => response.json())
+        .then(data => {
+            if (data.success) {
+                window.location.reload();
+            } else {
+                alert('Erreur: ' + data.message);
+            }
+        })
+        .catch(error => {
+            console.error('Erreur: ', error);
+            alert('Une erreur est survenue lors de la requête.');
+        });
 }

--- a/app/assets/js/admin/admin-section.js
+++ b/app/assets/js/admin/admin-section.js
@@ -1,69 +1,132 @@
-document.addEventListener('click', (e) => {
+/**
+ * Configurations de confirmation par action admin
+ * Utilisées par showConfirmModal (modal.js)
+ */
+const ADMIN_ACTION_CONFIGS = {
+    unblock: {
+        title:       'Débloquer l\'utilisateur',
+        msg:         'Êtes-vous sûr de vouloir débloquer cet utilisateur ?',
+        icon:        'fas fa-unlock',
+        confirmText: 'Débloquer',
+        danger:      false
+    },
+    restore: {
+        title:       'Réactiver l\'utilisateur',
+        msg:         'Êtes-vous sûr de vouloir réactiver ce compte supprimé ?',
+        icon:        'fas fa-undo',
+        confirmText: 'Réactiver',
+        danger:      false
+    },
+    promote: {
+        title:       'Promouvoir en administrateur',
+        msg:         'Êtes-vous sûr de vouloir promouvoir cet utilisateur en tant qu\'admin ?',
+        icon:        'fas fa-user-shield',
+        confirmText: 'Promouvoir',
+        danger:      false
+    },
+    demote: {
+        title:       'Rétrograder en utilisateur',
+        msg:         'Êtes-vous sûr de vouloir rétrograder cet administrateur en utilisateur normal ?',
+        icon:        'fas fa-user-minus',
+        confirmText: 'Rétrograder',
+        danger:      true
+    },
+    block: {
+        title:       'Bloquer l\'utilisateur',
+        msg:         'Êtes-vous sûr de vouloir bloquer cet utilisateur ?',
+        icon:        'fas fa-ban',
+        confirmText: 'Bloquer',
+        danger:      true
+    },
+    soft_delete: {
+        title:       'Supprimer l\'utilisateur',
+        msg:         'Êtes-vous sûr de vouloir supprimer cet utilisateur ? Cette action est réversible par un super-admin.',
+        icon:        'fas fa-trash-alt',
+        confirmText: 'Supprimer',
+        danger:      true
+    }
+};
 
+/**
+ * Affiche une modale de confirmation puis exécute le callback si confirmé.
+ *
+ * @param {string}   action - Clé de ADMIN_ACTION_CONFIGS
+ * @param {Function} onConfirm - Fonction à appeler si l'utilisateur confirme
+ */
+function confirmAdminAction(action, onConfirm) {
+    const cfg = ADMIN_ACTION_CONFIGS[action];
+
+    if (!cfg) {
+        onConfirm();
+        return;
+    }
+
+    window.showConfirmModal(
+        cfg.title,
+        cfg.msg,
+        onConfirm,
+        null,
+        {
+            icon:        cfg.icon,
+            confirmText: cfg.confirmText,
+            cancelText:  'Annuler',
+            danger:      cfg.danger
+        }
+    );
+}
+
+document.addEventListener('click', (e) => {
     if (!e.target.classList.contains('btn-unblock')) return;
 
     e.preventDefault();
 
     const button = e.target;
-    const form = button.closest('form');
-
-    const input = document.createElement('input');
-
-    input.type = "hidden";
-    input.name = "action";
-    input.value = button.value;
-
-    form.appendChild(input);
-    //form.querySelector('[name="action"]')?.remove();
-
+    const form   = button.closest('form');
     const action = button.value;
 
-    if (action === 'unblock' && !confirm('Débloquer cet utilisateur ?')) return;
-    if (action === 'restore' && !confirm('Réactiver cet utilisateur ?')) return;
+    const input   = document.createElement('input');
+    input.type    = 'hidden';
+    input.name    = 'action';
+    input.value   = action;
+    form.appendChild(input);
 
-    submitAdminAction(form);
+    confirmAdminAction(action, () => submitAdminAction(form));
 });
 
 document.addEventListener('change', (e) => {
-
     if (!e.target.classList.contains('js-admin-select')) return;
 
     e.preventDefault();
 
     const select = e.target;
-    const form = select.closest('form');
+    const form   = select.closest('form');
     const action = select.value;
 
-    // Confirmation pour promouvoir un utilisateur en tant qu'admin
-    if (action === 'promote' && !confirm('Promouvoir cet utilisateur en tant qu\'admin ?')) return;
-    if (action === 'demote' && !confirm('Rétrograder cet admin en utilisateur normal ?')) return;
-    if (action === 'block' && !confirm('Bloquer cet utilisateur ?')) return;
-    if (action === 'soft_delete' && !confirm('Suppremier cet utilisateur ?')) return;
+    if (!action) return;
 
-    submitAdminAction(form);
+    confirmAdminAction(action, () => submitAdminAction(form));
 });
 
 function submitAdminAction(form) {
     const formData = new FormData(form);
 
-    fetch(window.location.pathname + window.location.search, { // On envoie à l'URL actuelle
+    fetch(window.location.pathname + window.location.search, {
         method: 'POST',
         body: formData,
         headers: {
-            'X-Requested-With': 'XMLHttpRequest' // On indique à PHP de détecter l'AJAX
+            'X-Requested-With': 'XMLHttpRequest'
         }
     })
     .then(response => response.json())
     .then(data => {
         if (data.success) {
-            // La page sera rechargé mais on aura une expérience plus fluide
             window.location.reload();
         } else {
-            alert("Erreur: " + data.message);
+            alert('Erreur: ' + data.message);
         }
     })
     .catch(error => {
         console.error('Erreur: ', error);
-        alert("Une erreur est survenue lors de la requête.");
-    })
+        alert('Une erreur est survenue lors de la requête.');
+    });
 }

--- a/app/assets/js/delete-account.js
+++ b/app/assets/js/delete-account.js
@@ -202,14 +202,27 @@
             return false;
         }
 
-        // Afficher une dernière confirmation
-        if (!confirm('Êtes-vous absolument sûr de vouloir supprimer votre compte ? Cette action est irréversible.')) {
-            e.preventDefault();
-            return false;
-        }
+        // Empêcher la soumission immédiate et attendre la confirmation via modale
+        e.preventDefault();
+        const form = e.target;
 
-        // Le formulaire peut être soumis
-        return true;
+        window.showConfirmModal(
+            'Supprimer mon compte',
+            'Êtes-vous absolument sûr de vouloir supprimer votre compte ? Cette action est définitive et irréversible.',
+            function () {
+                // form.submit() ne redéclenche pas l'événement submit → pas de boucle
+                form.submit();
+            },
+            null,
+            {
+                icon:        'fas fa-trash-alt',
+                confirmText: 'Supprimer définitivement',
+                cancelText:  'Annuler',
+                danger:      true
+            }
+        );
+
+        return false;
     }
 
     /**

--- a/app/assets/js/delete-account.js
+++ b/app/assets/js/delete-account.js
@@ -21,8 +21,7 @@
      *
      * @param {string} email - L'email de l'utilisateur à confirmer
      */
-    function initDeleteAccount(email)
-    {
+    function initDeleteAccount(email) {
         userEmail = email.toLowerCase().trim();
         emailInput = document.getElementById('confirm-email');
         deleteBtn = document.getElementById('deleteBtn');
@@ -61,8 +60,7 @@
      *
      * @param {HTMLElement} input - Le champ input
      */
-    function preventPaste(input)
-    {
+    function preventPaste(input) {
         // Empêcher Ctrl+V / Cmd+V
         input.addEventListener('paste', function (e) {
             e.preventDefault();
@@ -98,8 +96,7 @@
      *
      * @param {HTMLElement} input - Le champ input
      */
-    function preventDragDrop(input)
-    {
+    function preventDragDrop(input) {
         input.addEventListener('dragenter', function (e) {
             e.preventDefault();
             return false;
@@ -123,8 +120,7 @@
     /**
      * Gère la saisie dans le champ
      */
-    function handleInput(e)
-    {
+    function handleInput(e) {
         hasTyped = true;
         const value = e.target.value.toLowerCase().trim();
 
@@ -156,8 +152,7 @@
     /**
      * Gère les touches du clavier
      */
-    function handleKeyDown(e)
-    {
+    function handleKeyDown(e) {
         // Détecter si l'utilisateur essaie de coller avec Shift+Insert
         if (e.shiftKey && e.key === 'Insert') {
             e.preventDefault();
@@ -172,8 +167,7 @@
     /**
      * Gère le focus sur le champ
      */
-    function handleFocus()
-    {
+    function handleFocus() {
         // Vérifier si le presse-papiers a été modifié (détection indirecte)
         if (!hasTyped && emailInput.value.length > 0) {
             // Si du texte apparaît sans avoir tapé, c'est suspect
@@ -188,8 +182,7 @@
     /**
      * Gère la soumission du formulaire
      */
-    function handleSubmit(e)
-    {
+    function handleSubmit(e) {
         const value = emailInput.value.toLowerCase().trim();
 
         if (value !== userEmail) {
@@ -215,10 +208,10 @@
             },
             null,
             {
-                icon:        'fas fa-trash-alt',
+                icon: 'fas fa-trash-alt',
                 confirmText: 'Supprimer définitivement',
-                cancelText:  'Annuler',
-                danger:      true
+                cancelText: 'Annuler',
+                danger: true
             }
         );
 
@@ -230,8 +223,7 @@
      *
      * @param {string} message - Le message d'erreur
      */
-    function showError(message)
-    {
+    function showError(message) {
         if (emailError) {
             emailError.textContent = message;
             emailError.innerHTML = '<i class="fas fa-exclamation-circle"></i> ' + message;
@@ -242,8 +234,7 @@
     /**
      * Cache le message d'erreur
      */
-    function hideError()
-    {
+    function hideError() {
         if (emailError) {
             emailError.classList.remove('show');
         }

--- a/app/assets/js/delete-confirm.js
+++ b/app/assets/js/delete-confirm.js
@@ -1,6 +1,7 @@
 /**
- * Confirmation avant suppression (articles, événements)
- * Intercepte le clic sur le bouton pour afficher la confirmation AVANT la soumission.
+ * Confirmation avant suppression via modale (articles, événements)
+ * Intercepte le clic sur les boutons [data-confirm-msg].btn-delete
+ * et affiche une modale de confirmation au lieu du confirm() natif.
  */
 (function () {
     'use strict';
@@ -11,12 +12,26 @@
             if (!form) return;
 
             btn.addEventListener('click', function (e) {
-                var msg = btn.getAttribute('data-confirm-msg') || 'Êtes-vous sûr de vouloir supprimer ? Cette action est irréversible.';
-                if (!confirm(msg)) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    return false;
-                }
+                e.preventDefault();
+                e.stopPropagation();
+
+                var msg   = btn.getAttribute('data-confirm-msg')   || 'Êtes-vous sûr de vouloir supprimer ? Cette action est irréversible.';
+                var title = btn.getAttribute('data-confirm-title') || 'Confirmer la suppression';
+
+                window.showConfirmModal(
+                    title,
+                    msg,
+                    function () {
+                        form.submit();
+                    },
+                    null,
+                    {
+                        icon:        'fas fa-trash-alt',
+                        confirmText: 'Supprimer',
+                        cancelText:  'Annuler',
+                        danger:      true
+                    }
+                );
             }, true);
         });
     }


### PR DESCRIPTION
This pull request refactors the confirmation dialogs for destructive actions (such as deleting articles, events, or user accounts) across the application, replacing native browser `confirm()` popups with a unified, customizable modal confirmation system. This improves user experience and consistency, centralizes confirmation logic, and allows for richer UI feedback. Additionally, minor code style updates were made to improve readability.

**Confirmation Modal Refactoring**

* Replaced native `confirm()` dialogs for deleting articles and events in `listArticlesView.php` and `showEventView.php` with buttons that trigger a modal confirmation using `data-confirm-title` and `data-confirm-msg` attributes. (`app/Modules/views/articles/listArticlesView.php`, [[1]](diffhunk://#diff-d125a6d0982202c3da322467a4b3f65f5d5d811d4546a606d5f0971bb6c3b6adL99-R101); `app/Modules/views/events/showEventView.php`, [[2]](diffhunk://#diff-d65ba97b50106708168a1882cf9c6d9ffa285df502cb20ec64b5839e3f90ce26L121-R123)
* Updated `delete-confirm.js` to intercept clicks on `.btn-delete` buttons with confirmation data attributes and show a modal dialog via `window.showConfirmModal`, providing custom title, message, and styling. (`app/assets/js/delete-confirm.js`, [[1]](diffhunk://#diff-027e971672df61b99cd8ec9be822f2251b338dd8fc85134aa05cc02f386bbeaaL2-R4) [[2]](diffhunk://#diff-027e971672df61b99cd8ec9be822f2251b338dd8fc85134aa05cc02f386bbeaaL14-R34)
* Refactored account deletion flow in `delete-account.js` to use a modal confirmation instead of `confirm()`, preventing immediate form submission and ensuring the user explicitly confirms the action in a modal. (`app/assets/js/delete-account.js`, [app/assets/js/delete-account.jsL205-R226](diffhunk://#diff-99ba1d7fc547290818f2582b9716982351645def4f31c07ad53d51b104540af2L205-R226))

**Admin Actions Confirmation**

* Centralized admin action confirmation logic in `admin-section.js` by introducing an `ADMIN_ACTION_CONFIGS` object and a `confirmAdminAction` function, replacing scattered `confirm()` prompts with modal dialogs for actions like unblock, restore, promote, demote, block, and soft delete. (`app/assets/js/admin/admin-section.js`, [[1]](diffhunk://#diff-49b71d8069d2a5694bab5600652d4a5415a80f9db5be1d05d02207baab0a187cL1-L28) [[2]](diffhunk://#diff-49b71d8069d2a5694bab5600652d4a5415a80f9db5be1d05d02207baab0a187cL37-R131)

**Code Style Improvements**

* Standardized function declarations in `delete-account.js` to use concise syntax for better readability and maintainability. (`app/assets/js/delete-account.js`, [[1]](diffhunk://#diff-99ba1d7fc547290818f2582b9716982351645def4f31c07ad53d51b104540af2L24-R24) [[2]](diffhunk://#diff-99ba1d7fc547290818f2582b9716982351645def4f31c07ad53d51b104540af2L64-R63) [[3]](diffhunk://#diff-99ba1d7fc547290818f2582b9716982351645def4f31c07ad53d51b104540af2L101-R99) [[4]](diffhunk://#diff-99ba1d7fc547290818f2582b9716982351645def4f31c07ad53d51b104540af2L126-R123) [[5]](diffhunk://#diff-99ba1d7fc547290818f2582b9716982351645def4f31c07ad53d51b104540af2L159-R155) [[6]](diffhunk://#diff-99ba1d7fc547290818f2582b9716982351645def4f31c07ad53d51b104540af2L175-R170) [[7]](diffhunk://#diff-99ba1d7fc547290818f2582b9716982351645def4f31c07ad53d51b104540af2L191-R185) [[8]](diffhunk://#diff-99ba1d7fc547290818f2582b9716982351645def4f31c07ad53d51b104540af2L232-R237)